### PR TITLE
Translate lobby and highlight playable games

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -58,7 +58,6 @@ nav.main a.active,nav.main a:hover{border-color:var(--border); background:rgba(2
 .btn.primary{background:linear-gradient(135deg,var(--accent),#52f0d0); color:#07110d}
 .btn.secondary{background:rgba(255,255,255,.06); border:1px solid var(--border); color:#d6dee7}
 .btn.ghost{background:transparent;border:1px solid var(--border);}
-#pf-open{color:#fff}
 .btn.danger{background:linear-gradient(135deg,#ff5d5d,#ff7d7d); color:#220707}
 .icon{opacity:.9}
 input,select{

--- a/css/style.css
+++ b/css/style.css
@@ -58,6 +58,7 @@ nav.main a.active,nav.main a:hover{border-color:var(--border); background:rgba(2
 .btn.primary{background:linear-gradient(135deg,var(--accent),#52f0d0); color:#07110d}
 .btn.secondary{background:rgba(255,255,255,.06); border:1px solid var(--border); color:#d6dee7}
 .btn.ghost{background:transparent;border:1px solid var(--border);}
+#pf-open{color:#fff}
 .btn.danger{background:linear-gradient(135deg,#ff5d5d,#ff7d7d); color:#220707}
 .icon{opacity:.9}
 input,select{
@@ -92,6 +93,11 @@ label{font-size:.9rem;color:#a7b3c1}
 .tile .meta{display:flex;align-items:center;justify-content:space-between;padding:10px}
 .tile .title{font-weight:600}
 .tile .cta{padding:6px 10px; border-radius:10px; background:rgba(255,255,255,.06); border:1px solid var(--border)}
+.tile.playable{border-color:rgba(46,230,166,.5)}
+.tile.playable .cta{background:rgba(46,230,166,.12); border-color:rgba(46,230,166,.4); color:var(--accent)}
+.tile.upcoming{opacity:.5; pointer-events:none; cursor:default}
+.tile.upcoming .cta{color:#9fb0c2}
+.badge.upcoming{background:rgba(255,255,255,.06); border-color:var(--border); color:#9fb0c2}
 
 .footer{padding:24px; border-top:1px solid var(--border); color:#9fb0c2; display:flex; flex-wrap:wrap; gap:16px; justify-content:space-between}
 

--- a/games/blackjack/blackjack.html
+++ b/games/blackjack/blackjack.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="cs">
+<html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -43,7 +43,7 @@
     padding:10px 14px; border-radius:12px; border:1px solid var(--edge);
     background:linear-gradient(180deg, rgba(255,255,255,.06), transparent 50%), #152033;
     transition:transform .05s ease, filter .2s ease, background .2s ease, opacity .2s;
-    display:inline-flex; align-items:center; justify-content:center; /* proti svislému roztažení */
+    display:inline-flex; align-items:center; justify-content:center; /* prevent vertical stretching */
   }
   .btn:hover{ filter:brightness(1.1) }
   .btn:active{ transform:translateY(1px) }
@@ -93,14 +93,14 @@
   .zone{ padding:18px 0 }
   .zone+.zone{ border-top:1px dashed #22314f }
 
-  /* Dealer: skóre nad kartami (absolute) */
+  /* Dealer: score above cards (absolute) */
   .hand.dealer{ position:relative; padding:20px 0 }
   .hand.dealer .score{
     position:absolute; left:50%; transform:translateX(-50%); top:-12px;
     background:var(--chip); border:1px solid var(--edge); border-radius:10px; padding:6px 10px; font-weight:600;
   }
 
-  /* Hráč: karty vedle sebe, skóre POD kartami – statické */
+  /* Player: cards side by side, score BELOW cards – static */
   .player-hands{ display:grid; gap:16px }
   .hand.player{ position:relative; padding:12px 0 }
   .hand.player .score{
@@ -119,7 +119,7 @@
   .card{
     width:78px; height:114px; border-radius:10px; background:#e6ebf3;
     box-shadow:0 8px 20px rgba(0,0,0,.35); border:1px solid rgba(0,0,0,.15);
-    position:relative; transform:translateX(-80px); opacity:0; animation:flyin .6s ease forwards; /* pomalejší */
+    position:relative; transform:translateX(-80px); opacity:0; animation:flyin .6s ease forwards; /* slower */
   }
   @keyframes flyin{ to{ transform:translateX(0); opacity:1 } }
   .card .face{ position:absolute; inset:0; display:grid; place-items:center; font-weight:800; font-size:26px; color:#0c1524 }
@@ -137,7 +137,7 @@
   }
   .toast.show{ opacity:1; transform:translateY(0) }
 
-  /* Historie */
+  /* History */
   .history{ padding:12px }
   .history .item{
     padding:10px 12px; border:1px solid var(--edge); border-radius:10px; background:#0f1726;
@@ -151,7 +151,7 @@
     display:flex; gap:8px; padding:12px; border-top:1px solid var(--edge);
     background:linear-gradient(180deg, rgba(255,255,255,.03), transparent 30%), var(--panel);
     border-radius:0 0 14px 14px;
-    align-items:center; /* proti svislému roztahování tlačítek */
+    align-items:center; /* prevent vertical stretching of buttons */
     flex-wrap:wrap;
   }
   .tag{ font-size:11px; color:#08111e; background:var(--gold); border-radius:999px; padding:2px 8px; font-weight:700 }
@@ -160,20 +160,20 @@
 </head>
 <body>
   <div class="wrap">
-    <!-- LEVÝ PANEL: Balance & sázky -->
+    <!-- LEFT PANEL: Balance & Bets -->
     <aside class="panel" id="left">
-      <h2>Balance & sázka</h2>
+      <h2>Balance & Bet</h2>
       <div class="controls">
         <div class="lobby-row"><a class="lobby-btn" href="../../index.html">← Lobby</a></div>
         <div class="row">
           <div>
-            <div class="muted" style="font-size:12px">Zůstatek</div>
+            <div class="muted" style="font-size:12px">Balance</div>
             <div class="stat" id="balanceView" style="font-size:22px; font-weight:800">1 000.00</div>
           </div>
         </div>
         <div class="divider"></div>
         <div>
-          <div class="muted" style="font-size:12px">Sázka</div>
+          <div class="muted" style="font-size:12px">Bet</div>
           <div class="row"><input type="number" id="bet" min="1" step="1" value="10"></div>
           <div class="row">
             <button class="btn pill" data-betadd="10">+10</button>
@@ -187,16 +187,16 @@
         </div>
         <div class="divider"></div>
         <div class="row">
-          <button class="btn accent" id="dealBtn">Rozdat</button>
-          <button class="btn" id="newShoeBtn" title="Míchat 6 balíčků">Nový shoe</button>
+          <button class="btn accent" id="dealBtn">Deal</button>
+          <button class="btn" id="newShoeBtn" title="Shuffle 6 decks">New shoe</button>
         </div>
         <div class="muted" style="font-size:12px">
-          Pravidla: S17 • Blackjack 3:2 • Double po prvních 2 kartách • Split párů (10/J/Q/K lze) • Split A,A = 1 karta a stop • Bez pojištění.
+          Rules: S17 • Blackjack 3:2 • Double after first 2 cards • Split pairs (10/J/Q/K allowed) • Split A,A = 1 card then stand • No insurance.
         </div>
       </div>
     </aside>
 
-    <!-- STŮL -->
+    <!-- TABLE -->
     <main class="table panel">
       <div class="toast" id="toast"></div>
       <div class="felt" id="felt">
@@ -209,8 +209,8 @@
         </div>
 
         <div class="labels" style="margin-top:8px">
-          <div>Hráč</div>
-          <div class="muted stat" id="roundInfo">Shoe: 6×52 • Reshuffle pod 25 %</div>
+          <div>Player</div>
+          <div class="muted stat" id="roundInfo">Shoe: 6×52 • Reshuffle under 25%</div>
         </div>
 
         <div class="zone">
@@ -218,19 +218,19 @@
         </div>
       </div>
 
-      <!-- pořadí: Hit, Stand, Double, Split -->
+      <!-- order: Hit, Stand, Double, Split -->
       <div class="actionbar">
         <button class="btn good" id="hitBtn" disabled>Hit</button>
         <button class="btn bad" id="standBtn" disabled>Stand</button>
         <button class="btn accent" id="doubleBtn" disabled>Double</button>
         <button class="btn split" id="splitBtn" disabled>Split</button>
-        <div style="margin-left:auto" class="muted">Sázka: <span class="stat" id="betView">10</span></div>
+        <div style="margin-left:auto" class="muted">Bet: <span class="stat" id="betView">10</span></div>
       </div>
     </main>
 
-    <!-- PRAVÝ PANEL: Historie -->
+    <!-- RIGHT PANEL: History -->
     <aside class="panel">
-      <h2>Historie</h2>
+      <h2>History</h2>
       <div class="history" id="history"></div>
     </aside>
   </div>
@@ -238,7 +238,7 @@
 <script>
 (() => {
   // ---------- Utils ----------
-  const fmt = v => Number(v).toLocaleString('cs-CZ',{minimumFractionDigits:2,maximumFractionDigits:2});
+  const fmt = v => Number(v).toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2});
   const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
   const rngInt = (n)=>{
     if (window.crypto && crypto.getRandomValues){
@@ -300,7 +300,7 @@
   function ensureShoe(){
     if (!state.shoe.length || state.shoe.length < state.shoeSize*state.penetrationCutoff){
       state.shoe = buildShoe(6);
-      showToast('Nový shoe (6×52) zamíchán.'); updateRoundInfo();
+      showToast('New shoe (6×52) shuffled.'); updateRoundInfo();
     }
   }
   function drawCard(){ ensureShoe(); return state.shoe.pop(); }
@@ -339,7 +339,7 @@
   function updateRoundInfo(){
     const left=state.shoe.length,total=state.shoeSize||312;
     const pct=Math.round((left/total)*100);
-    el.roundInfo.textContent=`Shoe: 6×52 • Zbývá ~${pct}% • Reshuffle pod ${Math.round(state.penetrationCutoff*100)}%`;
+    el.roundInfo.textContent=`Shoe: 6×52 • Remaining ~${pct}% • Reshuffle under ${Math.round(state.penetrationCutoff*100)}%`;
   }
   function renderBalance(){ walletSet(state.balance); el.balanceView.textContent=fmt(state.balance); }
   function syncBetUI(){ el.betView.textContent=fmt(state.baseBet); }
@@ -352,7 +352,7 @@
     wrap.dataset.handIndex=String(idx);
 
     const tag=document.createElement('div');
-    tag.className='bettag'; tag.textContent=`Sázka ${fmt(hand.bet)}`;
+    tag.className='bettag'; tag.textContent=`Bet ${fmt(hand.bet)}`;
     wrap.appendChild(tag);
 
     const cardsDiv=document.createElement('div'); cardsDiv.className='cards';
@@ -377,7 +377,7 @@
     const cardsDiv=wrap.querySelector('.cards');
     const have=Number(cardsDiv.dataset.cardsCount||0);
     for(let i=have;i<hand.cards.length;i++){
-      const delay=baseDelay + i*220; // pomalejší dávkování
+      const delay=baseDelay + i*220; // slower dealing
       cardsDiv.appendChild(cardEl(hand.cards[i],{delay}));
     }
     cardsDiv.dataset.cardsCount=String(hand.cards.length);
@@ -389,19 +389,19 @@
     });
   }
 
-  // Dealer – také append-only
+  // Dealer – append-only as well
   function dealerReset(showHole=false){
     el.dealer.innerHTML='';
-    // dvě karty přidáme s postupným zpožděním
+    // add two cards with sequential delay
     if (state.dealer[0]) el.dealer.appendChild(cardEl(state.dealer[0],{hidden:!showHole,delay:0}));
     if (state.dealer[1]) el.dealer.appendChild(cardEl(state.dealer[1],{hidden:false,delay:220}));
     el.dealerScore.textContent = showHole ? handValue(state.dealer) : (state.dealer.length ? '?' : '–');
   }
   function dealerRevealHole(){
-    // přepni první kartu z "back" na face
+    // flip first card from "back" to face
     const first=el.dealer.children[0];
     if (first){ first.classList.remove('back'); first.querySelector('.face')?.replaceChildren(); }
-    // přepiš celé, aby se doplnily symboly (jednodušeji překreslím první prvek):
+    // redraw entire first element to update symbols
     el.dealer.replaceChild(cardEl(state.dealer[0],{hidden:false,delay:0}), first);
     el.dealerScore.textContent = handValue(state.dealer);
   }
@@ -446,11 +446,11 @@
     const lh=document.createElement('div');
     const playerCards = state.playerHands[handIdx].cards;
     lh.innerHTML=`<div class="muted" style="font-size:12px">${result} (Hand ${handIdx+1})</div>
-                  <div>Hráč ${handValue(playerCards)} vs Dealer ${handValue(state.dealer)}</div>`;
+                  <div>Player ${handValue(playerCards)} vs Dealer ${handValue(state.dealer)}</div>`;
     const rh=document.createElement('div');
     const cls = profit>0?'win':(profit<0?'lose':'push');
     const bet = state.playerHands[handIdx].bet;
-    rh.innerHTML=`<div class="muted" style="font-size:12px">Sázka ${fmt(bet)}</div>
+    rh.innerHTML=`<div class="muted" style="font-size:12px">Bet ${fmt(bet)}</div>
                   <div class="delta ${cls}">${profit>0?'+':''}${fmt(profit)}</div>`;
     item.appendChild(lh); item.appendChild(rh); document.getElementById('history').prepend(item);
     const hist=document.getElementById('history');
@@ -461,8 +461,8 @@
   function startRound(){
     const bet = clamp(Math.floor(Number(el.betInput?.value ?? state.baseBet)),1,Math.floor(state.balance));
     state.baseBet = bet; syncBetUI();
-    if (bet<1){ showToast('Sázka je příliš nízká.'); return; }
-    if (bet>state.balance){ showToast('Nedostatek prostředků.'); return; }
+    if (bet<1){ showToast('Bet is too low.'); return; }
+    if (bet>state.balance){ showToast('Insufficient funds.'); return; }
 
     state.inRound = true;
     state.dealer = [];
@@ -472,20 +472,20 @@
 
     clearTable();
 
-    // Deal: P, D(hole), P, D(up) – pomalejší dávky
+    // Deal: P, D(hole), P, D(up) – slower rounds
     const p1=drawCard(), d1=drawCard(), p2=drawCard(), d2=drawCard();
     state.playerHands[0].cards.push(p1);
-    createPlayerHandDom(0); // vytvoří DOM a přidá 1. kartu
+    createPlayerHandDom(0); // create DOM and add first card
     setTimeout(()=>{
       state.dealer.push(d1);
-      dealerReset(false); // založí dealerovy karty (první schovaná)
+      dealerReset(false); // set up dealer cards (first hidden)
       setActions();
       setTimeout(()=>{
         state.playerHands[0].cards.push(p2);
         appendMissingCards(0, 0);
         setTimeout(()=>{
           state.dealer.push(d2);
-          dealerReset(false); // přidá druhou odkrytou
+          dealerReset(false); // add second face-up
           setActions();
           // Natural check
           setTimeout(()=>{
@@ -495,15 +495,15 @@
               dealerRevealHole();
               if (pBJ && dBJ){
                 state.balance += state.baseBet;
-                addHistoryLine('Push – oba blackjack', 0, 0);
-                showToast('Push – oba blackjack');
+                addHistoryLine('Push – both blackjack', 0, 0);
+                showToast('Push – both blackjack');
               } else if (pBJ){
                 const win = state.baseBet * 1.5;
                 state.balance += state.baseBet + win;
-                addHistoryLine('Výhra – Blackjack 3:2', +win, 0);
+                addHistoryLine('Win – Blackjack 3:2', +win, 0);
                 showToast('Blackjack! 3:2');
               } else {
-                addHistoryLine('Prohra – Dealer blackjack', -state.baseBet, 0);
+                addHistoryLine('Loss – Dealer blackjack', -state.baseBet, 0);
                 showToast('Dealer blackjack');
               }
               renderBalance();
@@ -540,12 +540,12 @@
   function doDouble(){
     const h = state.playerHands[state.activeHand];
     if (!state.inRound || !h || h.isDone || !h.canDouble || h.isSplitAces) return;
-    if (state.balance < h.bet){ showToast('Nedostatek prostředků pro Double.'); return; }
+    if (state.balance < h.bet){ showToast('Insufficient funds for Double.'); return; }
     state.balance -= h.bet; h.bet *= 2; h.canDouble=false; renderBalance();
 
     const c = drawCard(); h.cards.push(c);
     appendMissingCards(state.activeHand, 0);
-    h.isDone = true; // po double se stojí
+    h.isDone = true; // stand after double
     nextHandOrDealer();
   }
 
@@ -553,7 +553,7 @@
     const h = state.playerHands[state.activeHand];
     if (!state.inRound || !h || h.isDone || h.cards.length!==2) return;
     if (!canSplitNow(h)) return;
-    if (state.balance < h.bet){ showToast('Nedostatek prostředků pro Split.'); return; }
+    if (state.balance < h.bet){ showToast('Insufficient funds for Split.'); return; }
 
     const [c1, c2] = h.cards;
     const bet2 = h.bet;
@@ -561,24 +561,24 @@
 
     const splitAces = (c1.r==='A' && c2.r==='A');
 
-    // Připrav dvě ruce
+    // Prepare two hands
     h.cards = [c1]; h.canDouble = true; h.isDone = false; h.isSplitAces = splitAces;
     const newHand = { cards:[c2], bet:bet2, canDouble:true, isDone:false, isSplitAces:splitAces };
     state.playerHands.splice(state.activeHand+1, 0, newHand);
 
-    // Překresli pouze strukturu kontejneru rukou (bez mazání karet)
+    // Redraw only hand container structure (without removing cards)
     el.playerHands.innerHTML='';
     createPlayerHandDom(0);
     for(let i=1;i<state.playerHands.length;i++) createPlayerHandDom(i);
 
-    // Každé ruce rozdej 1 kartu (append-only)
+    // Deal 1 card to each hand (append-only)
     setTimeout(()=>{
       h.cards.push(drawCard()); appendMissingCards(state.activeHand, 0);
       newHand.cards.push(drawCard()); appendMissingCards(state.activeHand+1, 0);
 
       if (splitAces){
         h.isDone = true; newHand.isDone = true;
-        showToast('Split A,A – každá ruka 1 karta a stop');
+        showToast('Split A,A – each hand 1 card then stand');
         nextHandOrDealer();
       } else {
         setActions();
@@ -587,7 +587,7 @@
   }
 
   function nextHandOrDealer(){
-    // najdi další nedohranou ruku
+    // find next unfinished hand
     for (let i=0;i<state.playerHands.length;i++){
       const idx = (state.activeHand + 1 + i) % state.playerHands.length;
       if (!state.playerHands[idx].isDone){
@@ -603,7 +603,7 @@
       const v=handValue(state.dealer);
       if (v<17){
         state.dealer.push(drawCard()); dealerAppendNew();
-        setTimeout(step, 420); // pomalejší dohrávání dealera
+        setTimeout(step, 420); // slower dealer play
       }else{
         settleAll();
       }
@@ -616,15 +616,15 @@
     state.playerHands.forEach((h,idx)=>{
       const p = handValue(h.cards);
       let result='', profit=0;
-      if (p>21){ result='Prohra – Bust'; profit=-h.bet; }
-      else if (d>21){ result='Výhra – Dealer bust'; profit= h.bet; state.balance += h.bet*2; }
-      else if (p>d){ result='Výhra'; profit= h.bet; state.balance += h.bet*2; }
-      else if (p<d){ result='Prohra'; profit=-h.bet; }
+      if (p>21){ result='Loss – Bust'; profit=-h.bet; }
+      else if (d>21){ result='Win – Dealer bust'; profit= h.bet; state.balance += h.bet*2; }
+      else if (p>d){ result='Win'; profit= h.bet; state.balance += h.bet*2; }
+      else if (p<d){ result='Loss'; profit=-h.bet; }
       else { result='Push'; profit=0; state.balance += h.bet; }
       addHistoryLine(result, profit, idx);
     });
     renderBalance();
-    showToast('Konec kola');
+    showToast('Round over');
     endRound();
   }
 
@@ -639,9 +639,9 @@
   el.standBtn.addEventListener('click', doStand);
   el.doubleBtn.addEventListener('click', doDouble);
   el.splitBtn.addEventListener('click', doSplit);
-  el.newShoeBtn.addEventListener('click', ()=>{ state.shoe=[]; ensureShoe(); showToast('Shoe zamíchán.'); });
+  el.newShoeBtn.addEventListener('click', ()=>{ state.shoe=[]; ensureShoe(); showToast('Shoe shuffled.'); });
 
-  // Sázkové helpery
+  // Bet helpers
   document.querySelectorAll('[data-betadd]').forEach(b=>{
     b.addEventListener('click', ()=>{
       const add=Number(b.getAttribute('data-betadd'));
@@ -667,9 +667,9 @@
   el.betInput.addEventListener('change', ()=>{ state.baseBet = clamp(Math.floor(el.betInput.value),1,Math.floor(state.balance||1)); syncBetUI(); });
 
   // Init
-  ensureShoe(); renderBalance(); syncBetUI(); clearTable(); setActions(); // tlačítka nejsou roztažená
+  ensureShoe(); renderBalance(); syncBetUI(); clearTable(); setActions(); // buttons not stretched
 
-  // Klávesové zkratky
+  // Keyboard shortcuts
   window.addEventListener('keydown', (e)=>{
     if (e.key.toLowerCase()==='h') el.hitBtn.click();
     if (e.key.toLowerCase()==='s') el.standBtn.click();

--- a/games/dice/dice.html
+++ b/games/dice/dice.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="cs">
+<html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -76,7 +76,7 @@
   .line{
   position:relative; height:12px; border-radius:999px;
   background:#0b1526; outline:1px solid #1e3356;
-  overflow:visible; /* důležité, aby marker nebyl uříznut */
+  overflow:visible; /* important so marker isn't cut off */
 }
 .seg{ position:absolute; top:0; bottom:0; z-index:0; }
 .handle{ z-index:1; }
@@ -90,7 +90,7 @@
   pointer-events:none; z-index:2;
 }
 
-/* přidej vrstvy */
+/* add layers */
 .seg{ position:absolute; top:0; bottom:0; z-index:0; }
 .handle{ z-index:1; }
 .marker{ z-index:2; }
@@ -104,7 +104,7 @@
   /* Marker above the line, with tip */
   .marker{
     position:absolute; left:0%; transform:translate(-50%,-100%) translateX(-40px);
-    top:-10px; /* nad lajnou, tip míří na lajnu */
+    top:-10px; /* above the line, tip points to the line */
     min-width:84px; padding:8px 10px; border-radius:10px; text-align:center;
     background:#0d1729; border:1px solid var(--edge); color:var(--text);
     box-shadow:0 6px 20px rgba(0,0,0,.35);
@@ -153,7 +153,7 @@
     <a class="lobby-btn" href="../../index.html">← Lobby</a>
     <div class="brand">🎲 Dice (Mines skin)</div>
     <div class="pill">HE: <strong id="heTop">1.00%</strong></div>
-    <div class="pill">Pravidlo: <strong id="ruleTop">Under (target 49.00)</strong></div>
+    <div class="pill">Rule: <strong id="ruleTop">Under (target 49.00)</strong></div>
     <div class="balanceBox" id="balanceBox">
       <span>Balance:</span> <strong id="balance" class="balance-amount">1 000.00</strong>
     </div>
@@ -162,15 +162,15 @@
   <div class="wrap">
     <!-- LEFT: inputs -->
     <div class="card">
-      <h2>Sázka & režim</h2>
+      <h2>Bet & Mode</h2>
       <div class="section">
         <div class="col" style="gap:12px">
-          <!-- VLASTNÍ ČÁSTKA – samostatný plný řádek -->
+          <!-- CUSTOM AMOUNT – full row -->
           <div class="col">
-            <label class="muted" for="betAmount">Částka sázky</label>
+            <label class="muted" for="betAmount">Bet amount</label>
             <input id="betAmount" class="full" type="number" min="0" step="0.01" value="10" />
           </div>
-          <!-- AŽ PODTÍM tlačítka -->
+          <!-- BUTTONS BELOW -->
           <div class="row">
             <button class="btn ghost" data-bet="+1">+1</button>
             <button class="btn ghost" data-bet="+10">+10</button>
@@ -203,7 +203,7 @@
 
     <!-- CENTER: hero line -->
     <div class="card">
-      <h2>Hra</h2>
+      <h2>Game</h2>
       <div class="section hero">
         <div class="lineWrap" id="lineWrap">
           <div class="line" id="line">
@@ -216,7 +216,7 @@
             <div class="tick" style="left:100%"></div>
             <div class="handle" id="handle" title="Target"></div>
 
-            <!-- Marker žije uvnitř .line, takže left:% sedí přesně -->
+            <!-- Marker lives inside .line, so left:% aligns exactly -->
             <div class="marker" id="marker" style="display:none">
               <div class="roll" id="markerRoll">0.00</div>
               <div class="bet" id="markerBet">Bet: 0.00</div>
@@ -233,10 +233,10 @@
     </div>
   </div>
 
-  <!-- Moje sázky -->
+  <!-- My bets -->
   <div style="padding:0 16px 16px">
     <div class="card">
-      <h2>Moje sázky</h2>
+      <h2>My Bets</h2>
       <div class="section" id="tableMine"></div>
       <div class="history" id="history"></div>
     </div>
@@ -262,11 +262,11 @@
           </div>
         </div>
         <div class="row" style="margin-top:8px">
-          <button id="randomizeSeeds" class="btn">Náhodně</button>
-          <button id="pfClose" class="btn ghost">Zavřít</button>
+          <button id="randomizeSeeds" class="btn">Randomize</button>
+          <button id="pfClose" class="btn ghost">Close</button>
         </div>
         <div class="row" style="margin-top:8px">
-          <div class="muted" style="font-size:12px">Výsledek: <span class="mono">roll = (HMAC_SHA256(serverSeed, `${clientSeed}:${nonce}`)[0..3] / 2^32) × 100</span> (0–99.99). Každá sázka zvyšuje nonce o 1.</div>
+          <div class="muted" style="font-size:12px">Outcome: <span class="mono">roll = (HMAC_SHA256(serverSeed, `${clientSeed}:${nonce}`)[0..3] / 2^32) × 100</span> (0–99.99). Each bet increases the nonce by 1.</div>
         </div>
       </div>
     </div>
@@ -318,12 +318,12 @@
   function qa(s, r=document){ return Array.from(r.querySelectorAll(s)); }
   const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
   const fmt2 = n => (Math.round(n*100)/100).toFixed(2);
-  function nowTime(){ const d=new Date(); return d.toLocaleTimeString('cs-CZ',{hour:'2-digit',minute:'2-digit',second:'2-digit'}) }
-  function updateBalanceView(){ s.balance = walletGet(); el.balance.textContent = s.balance.toLocaleString('cs-CZ',{minimumFractionDigits:2,maximumFractionDigits:2}); }
+  function nowTime(){ const d=new Date(); return d.toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit',second:'2-digit'}) }
+  function updateBalanceView(){ s.balance = walletGet(); el.balance.textContent = s.balance.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2}); }
   function creditAnimation(amount){
     const tag = document.createElement('div');
     tag.className = 'creditFloat';
-    tag.textContent = `+${amount.toLocaleString('cs-CZ',{minimumFractionDigits:2,maximumFractionDigits:2})}`;
+    tag.textContent = `+${amount.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2})}`;
     el.balanceBox.appendChild(tag);
     el.balanceBox.classList.remove('balancePulse'); void el.balanceBox.offsetWidth; el.balanceBox.classList.add('balancePulse');
     setTimeout(()=> tag.remove(), 1000);
@@ -397,7 +397,7 @@
   // ===== Bets table & history =====
   function renderMine(){
     const rows = s.myBets.slice(0,200);
-    const headers = ['Čas','Sázka','Pravidlo','Výsledek','Stav','Výhra'];
+    const headers = ['Time','Bet','Rule','Roll','Status','Win'];
     const html = [
       '<div style="overflow:auto"><table><thead><tr>',
       ...headers.map(h=>`<th>${h}</th>`),
@@ -443,39 +443,39 @@
 
     s.rolling = true; setDisabled(true);
 
-   // Připrav marker – vždy start z LEVÉHO kraje
+  // Prepare marker – always start from LEFT edge
 const m = el.marker;
 m.style.display = 'block';
 m.className = 'marker';
 el.markerRoll.textContent = '…';
 el.markerBet.textContent = 'Bet: ' + fmt2(s.bet);
 
-// 1) Vypnout přechod a resetnout pozici na levý okraj
+// 1) Disable transition and reset position to left edge
 m.style.transition = 'none';
 m.style.left = '0%';
 m.style.transform = 'translate(-50%,-100%)';
 
-// Force reflow, ať se reset aplikuje
+// Force reflow so reset applies
 void m.offsetWidth;
 
-// 2) Vypočti výsledek a cílové % (jako už děláš)
+// 2) Compute result and target %
 const roll = await pfRoll(s.serverSeed, s.clientSeed, s.nonce);
 s.nonce++;
 const pct = Math.max(0, Math.min(99.99, roll));
 
-// 3) Zapnout přechod a spustit jízdu zleva → na cíl
+// 3) Enable transition and animate from left to target
 m.style.transition = 'left 0.9s cubic-bezier(.2,.8,.2,1), transform 0.9s cubic-bezier(.2,.8,.2,1)';
 el.markerRoll.textContent = roll.toFixed(2);
-m.style.left = pct + '%';          // tímto se rozjede animace z 0% na pct%
+ m.style.left = pct + '%';          // this starts animation from 0% to pct%
 m.style.transform = 'translate(-50%,-100%)';
 
-// počkej na dojetí (stejný čas jako v CSS)
+// wait for animation to finish (same duration as CSS)
 await new Promise(r=>setTimeout(r, 950));
 
-// ... dál beze změn: win/lose, barvy, balance, log atd.
+// rest unchanged: win/lose, colors, balance, log etc.
 
 
-    // Vyhodnocení
+    // Evaluation
     const win = (s.uo==='under') ? (roll < s.target) : (roll > s.target);
     const payout = ((100 - s.houseEdge) / s.chance);
     const won = win ? s.bet * payout : 0;
@@ -514,7 +514,7 @@ await new Promise(r=>setTimeout(r, 950));
     t.classList.add('active'); s.uo = t.dataset.uo; drawLine();
   }));
 
-  // Handle drag listeners už výše
+  // Handle drag listeners already above
 
   // PF dialog
   el.pfBtn.addEventListener('click', ()=> el.pfDialog.showModal());

--- a/games/plinko/plinko.html
+++ b/games/plinko/plinko.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="cs">
+<html lang="en">
 <head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1" name="viewport"/>

--- a/games/roulette/roulette.html
+++ b/games/roulette/roulette.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="cs">
+<html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Webová ruleta – EU (single‑zero)</title>
+<title>Roulette – EU (single-zero)</title>
 <style>
   :root{
     --bg:#0b0f14; --panel:#121825; --edge:#1c2940; --muted:#9bb0c9; --text:#e7f1fb;
@@ -117,15 +117,15 @@
 
     <div class="balance-pill">
       <strong>Balance</strong>
-      <input id="balance" type="text" inputmode="decimal" aria-label="Zůstatek" />
+      <input id="balance" type="text" inputmode="decimal" aria-label="Balance" />
     </div>
   </header>
 
   <main class="wrap">
     <!-- LEFT: WHEEL -->
-    <section class="panel wheel-panel" aria-label="Ruletové kolo">
+    <section class="panel wheel-panel" aria-label="Roulette Wheel">
       <div class="wheel-box">
-        <svg id="wheel" viewBox="-200 -200 400 400" aria-label="Kolo">
+        <svg id="wheel" viewBox="-200 -200 400 400" aria-label="Wheel">
           <g id="wheelGroup"></g>
           <g id="pockets"></g>
           <g id="labels"></g>
@@ -140,23 +140,23 @@
     </section>
 
     <!-- CENTER: TABLE -->
-    <section class="panel table-panel" aria-label="Plátno sázek">
-      <h3>Plátno sázek</h3>
-      <div id="table" class="betting-grid" role="grid" aria-label="Sázkové pole"></div>
+    <section class="panel table-panel" aria-label="Betting Board">
+      <h3>Betting Board</h3>
+      <div id="table" class="betting-grid" role="grid" aria-label="Betting Grid"></div>
 
       <div class="controls">
-        <div class="chip-row" id="chips" role="group" aria-label="Žetony">
+        <div class="chip-row" id="chips" role="group" aria-label="Chips">
           <!-- chip buttons injected -->
         </div>
         <div class="chip-custom">
-          <input id="chip-custom-value" placeholder="Vlastní žeton (např. 2.50)" inputmode="decimal" />
-          <button id="chip-add-btn" title="Přidat vlastní žeton">+ Přidat</button>
+          <input id="chip-custom-value" placeholder="Custom chip (e.g. 2.50)" inputmode="decimal" />
+          <button id="chip-add-btn" title="Add custom chip">+ Add</button>
         </div>
         <div class="action-row">
-          <button id="btn-undo" title="Krok zpět (Undo)">Undo</button>
-          <button id="btn-redo" title="Krok vpřed (Redo)">Redo</button>
-          <button id="btn-repeat" title="Opakovat minulé sázky">Repeat</button>
-          <button id="btn-double" title="Zdvojnásobit všechny položky">Double</button>
+          <button id="btn-undo" title="Undo">Undo</button>
+          <button id="btn-redo" title="Redo">Redo</button>
+          <button id="btn-repeat" title="Repeat previous bets">Repeat</button>
+          <button id="btn-double" title="Double all bets">Double</button>
         </div>
         <div class="spin-row">
           <button class="spin-btn" id="btn-spin">Spin</button>
@@ -164,20 +164,20 @@
             <input type="checkbox" id="pf-enable" /> Provably‑fair (HMAC)
           </label>
         </div>
-        <input id="client-seed" placeholder="Client seed (volitelné)" style="display:none" />
+        <input id="client-seed" placeholder="Client seed (optional)" style="display:none" />
       </div>
     </section>
 
     <!-- RIGHT: HISTORY -->
-    <aside class="panel history-panel" aria-label="Historie a výplaty">
-      <h3>Historie</h3>
+    <aside class="panel history-panel" aria-label="History and Payouts">
+      <h3>History</h3>
       <div id="history" class="history-list" aria-live="polite"></div>
 
       <h3>Info</h3>
       <div class="info-box">
-        <div>EU (single‑zero) pořadí kapes: <code>0, 32, 15, 19, 4, 21, 2, 25, 17, 34, 6, 27, 13, 36, 11, 30, 8, 23, 10, 5, 24, 16, 33, 1, 20, 14, 31, 9, 22, 18, 29, 7, 28, 12, 35, 3, 26</code></div>
-        <div>Výplaty: Straight 35:1 · Dozen/Column 2:1 · Red/Black/Even/Odd/Low/High 1:1</div>
-        <div>Tip: Pravé kliknutí na políčko = odebrat vybraný žeton. Dlouhý stisk na mobilu také odebere.</div>
+        <div>EU (single‑zero) pocket order: <code>0, 32, 15, 19, 4, 21, 2, 25, 17, 34, 6, 27, 13, 36, 11, 30, 8, 23, 10, 5, 24, 16, 33, 1, 20, 14, 31, 9, 22, 18, 29, 7, 28, 12, 35, 3, 26</code></div>
+        <div>Payouts: Straight 35:1 · Dozen/Column 2:1 · Red/Black/Even/Odd/Low/High 1:1</div>
+        <div>Tip: Right-click a cell to remove the selected chip. Long press on mobile also removes it.</div>
       </div>
     </aside>
   </main>
@@ -211,7 +211,7 @@
   const LOW = new Set(Array.from({length:18},(_,i)=>i+1));
   const HIGH = new Set(Array.from({length:18},(_,i)=>i+19));
 
-  let CHIP_VALUES = [1,5,25,100,500,1000]; // v centech: 0.01–10.00
+  let CHIP_VALUES = [1,5,25,100,500,1000]; // in cents: 0.01–10.00
   const STORAGE_KEYS = { seed:'roulette_server_seed', nonce:'roulette_nonce', client:'roulette_client_seed' };
   const WALLET_KEY = 'wallet.balance';
   function walletGet(){ try{ return Number(JSON.parse(localStorage.getItem(WALLET_KEY))||1000); }catch{ return 1000 } }
@@ -348,7 +348,7 @@
     tableEl.innerHTML = '';
     // Zero on the left spanning 3 rows
     const zero = makeCell('0','zero','straight-0', new Set([0]));
-    zero.title = 'Sázka: 0 (straight 35:1)';
+    zero.title = 'Bet: 0 (straight 35:1)';
     zero.style.gridColumn = '1';
     zero.style.gridRow = '1 / span 3';
     tableEl.appendChild(zero);
@@ -426,7 +426,7 @@
   // Custom chip add
   function addCustomChip(){
     const cents = toCents(chipCustomInput.value);
-    if(!cents || cents<=0){ showToast('Neplatná hodnota žetonu.'); return; }
+    if(!cents || cents<=0){ showToast('Invalid chip value.'); return; }
     if(!CHIP_VALUES.includes(cents)){
       CHIP_VALUES.push(cents);
       CHIP_VALUES = [...new Set(CHIP_VALUES)].filter(n=>Number.isFinite(n) && n>0);
@@ -469,7 +469,7 @@
     const def = keyToBet(key);
     if(!def) return;
     const cost = selectedChip;
-    if(balance < cost) return showToast('Nedostatečný zůstatek.');
+    if(balance < cost) return showToast('Insufficient balance.');
 
     balance -= cost; persistBalance();
     const cur = bets.get(key) || { ...def, stake:0 };
@@ -584,10 +584,10 @@
 
   function repeatBets(){
     if(spinning) return;
-    if(!lastRoundSnapshot || !lastRoundSnapshot.length) return showToast('Žádné předchozí sázky.');
+    if(!lastRoundSnapshot || !lastRoundSnapshot.length) return showToast('No previous bets.');
     // compute total cost
     let total=0; lastRoundSnapshot.forEach(([k,b])=> total+=b.stake);
-    if(balance<total) return showToast('Nedostatečný zůstatek pro Repeat.');
+    if(balance<total) return showToast('Insufficient balance for Repeat.');
     balance-=total; persistBalance();
     restoreBets(lastRoundSnapshot);
     updateBalanceUI();
@@ -596,8 +596,8 @@
   function doubleBets(){
     if(spinning) return;
     let total=0; for(const [k,b] of bets){ total+=b.stake; }
-    if(total===0) return showToast('Nejsou žádné sázky k zdvojnásobení.');
-    if(balance<total) return showToast('Nedostatečný zůstatek pro Double.');
+    if(total===0) return showToast('No bets to double.');
+    if(balance<total) return showToast('Insufficient balance for Double.');
     balance-=total; persistBalance();
     for(const [k,b] of bets){ b.stake*=2; const cell = document.querySelector(`.cell[data-key="${k}"]`); if(cell) renderCellChips(cell,b.stake); }
     updateBalanceUI();
@@ -744,7 +744,7 @@
 
   // ====== Spin flow ======
   async function doSpin(){
-    if(spinning) return; if(bets.size===0) return showToast('Nejdřív něco vsadit.');
+    if(spinning) return; if(bets.size===0) return showToast('Place a bet first.');
     spinning = true; lockUI(true);
     clearHighlights();
 
@@ -774,8 +774,8 @@
 
     // Settle
     const {win, lose, net} = settleBets(finalNumber);
-    if(net>=0) showToast(`Výsledek: ${finalNumber} ${RED.has(finalNumber)?'(Red)':'(Black/Green)'} · Výhra ${fmt(win)} (net ${fmt(net)})`);
-    else showToast(`Výsledek: ${finalNumber} ${RED.has(finalNumber)?'(Red)':'(Black/Green)'} · Prohra ${fmt(-net)}`);
+    if(net>=0) showToast(`Result: ${finalNumber} ${RED.has(finalNumber)?'(Red)':'(Black/Green)'} · Win ${fmt(win)} (net ${fmt(net)})`);
+    else showToast(`Result: ${finalNumber} ${RED.has(finalNumber)?'(Red)':'(Black/Green)'} · Loss ${fmt(-net)}`);
 
     if(pfEnable.checked){ nonce++; localStorage.setItem(STORAGE_KEYS.nonce, String(nonce)); nonceEl.textContent = String(nonce); }
 
@@ -824,7 +824,7 @@
   function lockUI(state){ btnSpin.disabled=state; mSpin.disabled=state; document.querySelectorAll('.cell').forEach(c=>c.disabled=state); }
 
   // ====== Seeds controls ======
-  function newServerSeed(){ serverSeed = crypto.getRandomValues(new Uint32Array(4)).join('-'); localStorage.setItem(STORAGE_KEYS.seed, serverSeed); nonce=0; localStorage.setItem(STORAGE_KEYS.nonce,'0'); nonceEl.textContent='0'; updateSeedHash(); showToast('Vygenerován nový server seed.'); }
+  function newServerSeed(){ serverSeed = crypto.getRandomValues(new Uint32Array(4)).join('-'); localStorage.setItem(STORAGE_KEYS.seed, serverSeed); nonce=0; localStorage.setItem(STORAGE_KEYS.nonce,'0'); nonceEl.textContent='0'; updateSeedHash(); showToast('New server seed generated.'); }
 
   // ====== Events ======
   btnSpin.addEventListener('click', doSpin); mSpin.addEventListener('click', doSpin);

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           <span class="amount balance-amount">0.00</span>
         </div>
         <button class="btn secondary wallet-open">Deposit / Withdraw</button>
-        <button class="btn ghost" id="pf-open">Provably Fair</button>
+        <button class="pill" id="pf-open">Provably Fair</button>
         <button class="btn ghost">🔔</button>
         <div class="pill"><span class="icon">👤</span><span>Profile</span></div>
       </div>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="cs">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Casino Hub – Lokální demo</title>
+  <title>Casino Hub – Local Demo</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -14,9 +14,9 @@
         <a class="active">Lobby</a>
         <a href="#">Slots</a>
         <a href="#">Live</a>
-        <a href="#">Minihry</a>
+        <a href="#">Minigames</a>
         <a href="#">Promo</a>
-        <a href="#">Turnaje</a>
+        <a href="#">Tournaments</a>
       </nav>
       <div class="tools">
         <div class="pill wallet-open" style="cursor:pointer">
@@ -26,7 +26,7 @@
         <button class="btn secondary wallet-open">Deposit / Withdraw</button>
         <button class="btn ghost" id="pf-open">Provably Fair</button>
         <button class="btn ghost">🔔</button>
-        <div class="pill"><span class="icon">👤</span><span>Profil</span></div>
+        <div class="pill"><span class="icon">👤</span><span>Profile</span></div>
       </div>
     </div>
   </header>
@@ -34,31 +34,31 @@
   <div class="layout">
     <aside class="sidebar">
       <div class="card">
-        <h3>Rychlé filtry</h3>
+        <h3>Quick Filters</h3>
         <div class="row" style="flex-wrap:wrap">
-          <span class="tag active">Populární</span>
-          <span class="tag">Nové</span>
-          <span class="tag">Provably fair</span>
-          <span class="tag">Vysoká volatilita</span>
-          <span class="tag">Nízká volatilita</span>
+          <span class="tag active">Popular</span>
+          <span class="tag">New</span>
+          <span class="tag">Provably Fair</span>
+          <span class="tag">High volatility</span>
+          <span class="tag">Low volatility</span>
         </div>
       </div>
       <div class="card">
-        <h3>Kolekce</h3>
+        <h3>Collections</h3>
         <div class="row" style="flex-wrap:wrap">
-          <span class="tag">Klasika</span>
-          <span class="tag">Vysoké násobky</span>
-          <span class="tag">Rychlovky</span>
+          <span class="tag">Classics</span>
+          <span class="tag">High multipliers</span>
+          <span class="tag">Quick plays</span>
         </div>
       </div>
     </aside>
 
     <main>
       <div class="container" style="padding-top:0">
-        <h2>Hry</h2>
+        <h2>Games</h2>
         <div class="grid">
           <!-- Tiles -->
-          <a class="tile" href="games/mines/mines.html">
+          <a class="tile playable" href="games/mines/mines.html">
             <div class="badge">Hot</div>
             <div class="thumb">
               <!-- diamond -->
@@ -66,53 +66,61 @@
             </div>
             <div class="meta"><div class="title">Mines</div><div class="cta">Play</div></div>
           </a>
-          <a class="tile" href="games/crash/crash.html">
+          <a class="tile upcoming" href="#">
+            <div class="badge upcoming">Upcoming</div>
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><path d="M10 90 L20 70 L30 75 L50 40 L70 50 L90 10" fill="none" stroke="#27c6e5" stroke-width="3"/></svg></div>
-            <div class="meta"><div class="title">Crash</div><div class="cta">Play</div></div>
+            <div class="meta"><div class="title">Crash</div><div class="cta">Upcoming</div></div>
           </a>
-          <a class="tile" href="games/plinko/plinko.html">
+          <a class="tile playable" href="games/plinko/plinko.html">
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><circle cx="50" cy="20" r="6" stroke="#2ee6a6" fill="none"/><circle cx="30" cy="40" r="4" stroke="#fff" fill="none"/><circle cx="70" cy="40" r="4" stroke="#fff" fill="none"/><circle cx="50" cy="60" r="4" stroke="#fff" fill="none"/></svg></div>
             <div class="meta"><div class="title">Plinko</div><div class="cta">Play</div></div>
           </a>
-          <a class="tile" href="games/dice/dice.html">
+          <a class="tile playable" href="games/dice/dice.html">
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><rect x="20" y="20" width="60" height="60" rx="8" stroke="#fff" fill="none"/><circle cx="40" cy="40" r="5" fill="#fff"/><circle cx="60" cy="60" r="5" fill="#fff"/></svg></div>
             <div class="meta"><div class="title">Dice</div><div class="cta">Play</div></div>
           </a>
-          <a class="tile" href="games/limbo/limbo.html">
+          <a class="tile upcoming" href="#">
+            <div class="badge upcoming">Upcoming</div>
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><text x="50" y="60" text-anchor="middle" font-size="36" fill="#2ee6a6">×</text></svg></div>
-            <div class="meta"><div class="title">Limbo</div><div class="cta">Play</div></div>
+            <div class="meta"><div class="title">Limbo</div><div class="cta">Upcoming</div></div>
           </a>
-          <a class="tile" href="games/towers/towers.html">
+          <a class="tile upcoming" href="#">
+            <div class="badge upcoming">Upcoming</div>
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><rect x="40" y="20" width="20" height="60" stroke="#fff" fill="none"/><rect x="35" y="80" width="30" height="8" fill="#fff"/></svg></div>
-            <div class="meta"><div class="title">Towers</div><div class="cta">Play</div></div>
+            <div class="meta"><div class="title">Towers</div><div class="cta">Upcoming</div></div>
           </a>
-          <a class="tile" href="games/keno/keno.html">
+          <a class="tile upcoming" href="#">
+            <div class="badge upcoming">Upcoming</div>
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><circle cx="35" cy="50" r="12" stroke="#fff" fill="none"/><circle cx="65" cy="50" r="12" stroke="#fff" fill="none"/><text x="35" y="55" text-anchor="middle" font-size="10">7</text><text x="65" y="55" text-anchor="middle" font-size="10">21</text></svg></div>
-            <div class="meta"><div class="title">Keno</div><div class="cta">Play</div></div>
+            <div class="meta"><div class="title">Keno</div><div class="cta">Upcoming</div></div>
           </a>
-          <a class="tile" href="games/wheel/wheel.html">
+          <a class="tile upcoming" href="#">
+            <div class="badge upcoming">Upcoming</div>
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><circle cx="50" cy="50" r="30" stroke="#fff" fill="none"/><line x1="50" y1="20" x2="50" y2="80" stroke="#fff"/><line x1="20" y1="50" x2="80" y2="50" stroke="#fff"/></svg></div>
-            <div class="meta"><div class="title">Wheel</div><div class="cta">Spin</div></div>
+            <div class="meta"><div class="title">Wheel</div><div class="cta">Upcoming</div></div>
           </a>
-          <a class="tile" href="games/hilo/hilo.html">
+          <a class="tile upcoming" href="#">
+            <div class="badge upcoming">Upcoming</div>
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><path d="M25 70 L50 30 L75 70 Z" stroke="#2ee6a6" fill="none"/></svg></div>
-            <div class="meta"><div class="title">Hi–Lo</div><div class="cta">Play</div></div>
+            <div class="meta"><div class="title">Hi–Lo</div><div class="cta">Upcoming</div></div>
           </a>
-          <a class="tile" href="games/coinflip/coinflip.html">
+          <a class="tile upcoming" href="#">
+            <div class="badge upcoming">Upcoming</div>
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><ellipse cx="50" cy="50" rx="26" ry="34" stroke="#fff" fill="none"/></svg></div>
-            <div class="meta"><div class="title">Coinflip</div><div class="cta">Flip</div></div>
+            <div class="meta"><div class="title">Coinflip</div><div class="cta">Upcoming</div></div>
           </a>
-          <a class="tile" href="games/roulette/roulette.html">
+          <a class="tile playable" href="games/roulette/roulette.html">
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><circle cx="50" cy="50" r="30" stroke="#fff" fill="none"/><circle cx="50" cy="50" r="4" fill="#fff"/></svg></div>
             <div class="meta"><div class="title">Roulette</div><div class="cta">Play</div></div>
           </a>
-          <a class="tile" href="games/blackjack/blackjack.html">
+          <a class="tile playable" href="games/blackjack/blackjack.html">
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><rect x="30" y="20" width="30" height="40" rx="6" stroke="#fff" fill="none"/><rect x="40" y="35" width="30" height="40" rx="6" stroke="#fff" fill="none"/></svg></div>
             <div class="meta"><div class="title">Blackjack</div><div class="cta">Play</div></div>
           </a>
-          <a class="tile" href="games/slots/slots.html">
+          <a class="tile upcoming" href="#">
+            <div class="badge upcoming">Upcoming</div>
             <div class="thumb"><svg width="80" height="80" viewBox="0 0 100 100"><rect x="20" y="25" width="60" height="50" rx="10" stroke="#fff" fill="none"/><text x="50" y="55" font-size="16" text-anchor="middle">777</text></svg></div>
-            <div class="meta"><div class="title">Slots</div><div class="cta">Spin</div></div>
+            <div class="meta"><div class="title">Slots</div><div class="cta">Upcoming</div></div>
           </a>
         </div>
       </div>
@@ -125,14 +133,14 @@
       </div>
       <div class="card">
         <h3>Promo</h3>
-        <div class="alert">Denní úkol: Získej 3× výhru v libovolné hře.</div>
+        <div class="alert">Daily task: Get 3 wins in any game.</div>
       </div>
     </aside>
   </div>
 
   <div class="footer">
-    <div>© Lokální demo. Odpovědné hraní. Podmínky. Nápověda.</div>
-    <div>Jazyk: Čeština • Region: CZ</div>
+    <div>© Local demo. Responsible gaming. Terms. Help.</div>
+    <div>Language: English • Region: CZ</div>
   </div>
 
   <!-- Wallet modal -->
@@ -140,28 +148,28 @@
     <div class="overlay"></div>
     <div class="window">
       <button class="btn ghost close">✕</button>
-      <h2>Peněženka</h2>
+      <h2>Wallet</h2>
       <div class="row" style="gap:16px;align-items:flex-end;flex-wrap:wrap">
         <div class="card" style="flex:1;min-width:260px">
           <h3>Deposit</h3>
-          <label>Částka</label>
+          <label>Amount</label>
           <input id="dep-amount" type="number" min="0" step="1" placeholder="0">
           <div class="quick-adds" style="margin-top:8px">
             <button class="btn secondary dep-add" data-v="10">+10</button>
             <button class="btn secondary dep-add" data-v="50">+50</button>
             <button class="btn secondary dep-add" data-v="250">+250</button>
-            <button class="btn primary" id="do-deposit">Vložit</button>
+            <button class="btn primary" id="do-deposit">Deposit</button>
           </div>
         </div>
         <div class="card" style="flex:1;min-width:260px">
           <h3>Withdraw</h3>
-          <label>Částka</label>
+          <label>Amount</label>
           <input id="wdr-amount" type="number" min="0" step="1" placeholder="0">
           <div class="quick-adds" style="margin-top:8px">
             <button class="btn secondary wdr-add" data-v="10">+10</button>
             <button class="btn secondary wdr-add" data-v="50">+50</button>
             <button class="btn secondary wdr-add" data-v="250">+250</button>
-            <button class="btn danger" id="do-withdraw">Vybrat</button>
+            <button class="btn danger" id="do-withdraw">Withdraw</button>
           </div>
         </div>
       </div>
@@ -181,9 +189,9 @@
           <div class="row" style="margin-top:8px"><strong>Nonce:</strong> <span id="pf-nonce">0</span></div>
         </div>
         <div class="card" style="flex:1">
-          <h3>Verifikace výsledku</h3>
-          <div class="alert">Každé kolo využívá HMAC-SHA256(server, client:nonce:i) → RNG ⟶ výsledek.</div>
-          <p>Výsledky jsou deterministické pro zadané vstupy.</p>
+          <h3>Result Verification</h3>
+          <div class="alert">Each round uses HMAC-SHA256(server, client:nonce:i) → RNG ⟶ result.</div>
+          <p>Results are deterministic for the given inputs.</p>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           <span class="amount balance-amount">0.00</span>
         </div>
         <button class="btn secondary wallet-open">Deposit / Withdraw</button>
-        <button class="pill" id="pf-open">Provably Fair</button>
+        <div class="pill" id="pf-open" style="cursor:pointer">Provably Fair</div>
         <button class="btn ghost">🔔</button>
         <div class="pill"><span class="icon">👤</span><span>Profile</span></div>
       </div>

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
 
   <div class="footer">
     <div>© Local demo. Responsible gaming. Terms. Help.</div>
-    <div>Language: English • Region: CZ</div>
+    <div>Language: English • Region: US</div>
   </div>
 
   <!-- Wallet modal -->


### PR DESCRIPTION
## Summary
- Translate lobby content and wallet modal to English
- Highlight playable games and mark remaining titles as upcoming
- Ensure "Provably Fair" button text is white

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf0cbdc148321b28ff8a90df305d3